### PR TITLE
invoke eups distrib install with --no-server-tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR $NEW_DIR
 
 RUN curl -sSL https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh | bash -s -- -cbtS
 
-RUN source ./loadLSST.bash; for prod in $PRODUCT; do eups distrib install -vvv $prod -t $TAG; done \
+RUN source ./loadLSST.bash; for prod in $PRODUCT; do eups distrib install --no-server-tags -vvv $prod -t $TAG; done \
   && ( find stack | xargs strip --strip-unneeded --preserve-dates \
        > /dev/null 2>&1 || true ) \
   && ( find stack -maxdepth 5 -name tests -type d -exec rm -rf {} \; \


### PR DESCRIPTION
To reduce metadata noise in the constructed image.