### PR TITLE
Revert "Merge pull request #22 from ktlim/tickets/DM-30913"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,7 @@ LABEL EUPS_PRODUCTS=$EUPS_PRODUCTS \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-lc"]
 
-RUN source ./loadLSST.bash; \
-  conda install -y --no-update-deps rubin-env==$LSST_SPLENV_REF \
-  && for prod in $EUPS_PRODUCTS; do eups distrib install --no-server-tags -vvv "$prod" -t "$EUPS_TAG"; done \
+RUN source ./loadLSST.bash; for prod in $EUPS_PRODUCTS; do eups distrib install --no-server-tags -vvv "$prod" -t "$EUPS_TAG"; done \
   && ( find stack -exec strip --strip-unneeded --preserve-dates {} + \
        > /dev/null 2>&1 || true ) \
   && ( find stack -maxdepth 5 -name tests -type d -exec rm -rf {} + \


### PR DESCRIPTION
This reverts commit 41a106f2d9b8f824d349bf087f6fdb4618b6677f, reversing
changes made to 3ad3922b8e18eeb8e64e7d4c3297c1d050b1899c.

There are problems solving the environment with rubin-env 0.6.0 build 2
installed on top of 0.6.0 build 1, so remove this update for now.